### PR TITLE
Add Telegram support, colors and puzzle solving timestamps

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
   release:
     types:
       - published

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ github.repository_owner }}
+          username: tofran
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
       - name: Login to GitHub container registry
@@ -45,7 +45,7 @@ jobs:
         with:
           images: |
             name=ghcr.io/${{ github.repository }}
-            name=${{ github.repository }},enable=${{ github.event_name != 'pull_request' }}
+            name=tofran/advent-of-code-leaderboard-notifier,enable=${{ github.event_name != 'pull_request' }}
           tags: |
             type=sha
             type=ref,event=branch

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: tofran
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
       - name: Login to GitHub container registry
@@ -45,7 +45,7 @@ jobs:
         with:
           images: |
             name=ghcr.io/${{ github.repository }}
-            name=tofran/advent-of-code-leaderboard-notifier,enable=${{ github.event_name != 'pull_request' }}
+            name=${{ github.repository }},enable=${{ github.event_name != 'pull_request' }}
           tags: |
             type=sha
             type=ref,event=branch

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,8 +2,6 @@ name: Lint
 
 on:
   push:
-    branches:
-      - main
   pull_request:
   workflow_dispatch:
 
@@ -16,7 +14,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Lint
-        run: make lint
+        run: make install-deps lint

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .env
 cache.json
+.vscode
+*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 .env
+env
+
 cache.json
+
 .vscode
 *.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,5 @@ WORKDIR /app
 COPY ./requirements.txt ./
 RUN pip install --upgrade pip && pip install -r requirements.txt
 
-COPY ./advent_of_code_notify.py ./advent_of_code_notify.py
+COPY ./*.py .
 CMD "./advent_of_code_notify.py"

--- a/README.md
+++ b/README.md
@@ -2,37 +2,39 @@
 
 Send a webhook or notification when someone from an Advent of Code leaderboard solves a puzzle.
 
-We are using this to track the progress of a group of friends on Discord/Telegram.
+This can be very useful to track the progress of a group of friends, or co-workers on Discord,
+Telegram, Slack, etc.
 
-<img src='https://github.com/tofran/advent-of-code-leaderboard-notifier/assets/5229130/289bc0e7-5def-4ffa-a21f-53d4eeb8f695' height='200'>
+![Example discord notification](https://user-images.githubusercontent.com/5692603/100946056-738cae80-34fa-11eb-833f-645b8ea2e116.png)
+
+![Example Telegram notification](https://github.com/tofran/advent-of-code-leaderboard-notifier/assets/5692603/37933eee-49ca-409c-9689-4eb10d2aa37a)
 
 ## Usage
 
-Just run this image whenever you want to check for updates:
+The image is available in the [GitHub Package Registry] and [Docker Hub]:
+
+Either run the image periodically (ex: cronjob) or run it continuously with `LOOP_SLEEP_SECONDS`.
+It will send puzzle solution events to the configured destination.
+
+### Examples
+
+**Simple Discord/Slack/custom webhook**
 
 ```sh
-# Discord/Slack/custom webhook/etc.
-$ docker run \
+docker run \
   -e WEBHOOK_URL="your webhook url" \
   -e ADVENT_OF_CODE_SESSION_ID="your advent of code session id" \
   -e ADVENT_OF_CODE_LEADERBOARD_ID="numeric leaderboard id" \
   -e CACHE_FILE="/cache/cache.json" \
-  -v "$(pwd)/cache/:/cache/" \
-  # (Optional: run it as a background service)
+  # Optional - run it continuously as a background service:
   # -e LOOP_SLEEP_SECONDS="900" --restart=unless-stopped -d \
-  # (Optional: customize the emojis in the notification)
-  # -e NOTIFICATION_PATTERN_EMOJIS="⭐🌟"
-  # -e NOTIFICATION_PATTERN_EMOJIS="🌲🎄"
-  # -e NOTIFICATION_PATTERN_EMOJIS="🌱🎄"
-  # -e NOTIFICATION_PATTERN_EMOJIS="🔵🟡"
-  # -e NOTIFICATION_PATTERN_EMOJIS="🥈🥇"
-  # (Optional: customize the notification text, see more keys below)
-  # -e NOTIFICATION_PATTERN="{member} solved {day}.{part} {part_emoji} at {mmss}"
-  # (Optional: customize just the part 2 notification)
-  # -e NOTIFICATION_2_PATTERN="{member} solved the 🎉🍾SECOND 🎄💥 part of day {day}! MORE EMOJIS!!!"
+  -v "$(pwd)/cache/:/cache/" \
   ghcr.io/tofran/advent-of-code-leaderboard-notifier
+```
 
-# Telegram
+**Telegram**
+
+```sh
 $ docker run \
   -e NOTIFICATION_SENDER=telegram \
   -e TELEGRAM_BOT_TOKEN="bot token" \
@@ -41,47 +43,56 @@ $ docker run \
   -e ADVENT_OF_CODE_LEADERBOARD_ID="numeric leaderboard id" \
   -e CACHE_FILE="/cache/cache.json" \
   -v "$(pwd)/cache/:/cache/" \
-  # (Same optionals, see above)
+  # (Same optional env vars, see below)
   ghcr.io/tofran/advent-of-code-leaderboard-notifier
-
 ```
-
-It should exit successfully. Run it periodically (at a minimum interval of 15 min),
-or pass the `LOOP_SLEEP_SECONDS` env var to make the script loop.
 
 ### Configuration
 
 #### - `ADVENT_OF_CODE_LEADERBOARD_ID`
 
-The unique ID of the leaderboard. It's an integer you can get from the end of leaderboard url or the prefix of the invite code.
+The unique ID of the leaderboard. It's an integer you can get from the end of leaderboard url or
+the prefix of the invite code.
 
 #### - `ADVENT_OF_CODE_SESSION_ID`
 
-Your advent of code session id. To retrieve it, visit adventofcode.com, open developer tools > storage > cookies > copy the value of your `session` cookie.
+Your advent of code session id. To retrieve it, visit adventofcode.com,
+open developer tools > storage > cookies > copy the value of your `session` cookie.
 
 #### - `LOOP_SLEEP_SECONDS` (optional)
 
-Defaults to `0`, meaning it only runs once and terminates the process. Otherwise set it to how many seconds to sleep between runs. It is recommended a value greater than `900` (15 min).
+Defaults to `0`, meaning it only runs once and terminates the process.
+Otherwise set it to how many seconds to sleep between runs.
+It is recommended a value greater than `900` (15 min) - following the Advent of Code recommendation.
 
 #### - `NOTIFICATION_PATTERN` (optional)
 
-Customizes the notification text. Defaults to `Day {day}: {member} got {part_emoji} after {after}`. Supported keys:
+Customizes the notification text.
+Defaults to `Day {day}: {member} solved {part_emoji} after {after}`. Supported keys:
 
-- `member`: the leaderbord member's name
-- `member_id`: the leaderbord member's id
+- `member`: the leaderboard member's name
+- `member_id`: the leaderboard member's id
 - `day`: the day number
 - `part`: the part number
 - `part_emoji`: the part emoji (see `NOTIFICATION_PATTERN_EMOJIS`)
-- `mmss`: when the puzzle was solved in `:mm:ss` format (no hours because timezones, still useful given 15 mins check interval)
-- `after`: how much time has passed since puzzle publication when it was solved in `[d] hh:mm:ss` format.
+- `after`: how much time has passed since puzzle publication `[d] hh:mm:ss` format.
+- `mmss`: when the puzzle was solved in `:mm:ss` format.  
+  Does not respect timezones (works okay in most timezones - with an offset multiple of the hour)  
+  Unstable: might have breaking changes in minor versions.
 
 #### - `NOTIFICATION_2_PATTERN` (optional)
 
-Defaults to the current value of `NOTIFICATION_PATTERN`. Customizes just the notification text for part 2 specifically.
+Defaults to the current value of `NOTIFICATION_PATTERN`.
+Overrides the notification text for the 2dn puzzle only.
+Example: `{member} solved the 🎉🍾 SECOND 🎄💥 part of day {day}!!!`
 
 #### - `NOTIFICATION_PATTERN_EMOJIS` (optional)
 
-Defaults to `🌱🎄`. A string of emojis to use for the `part_emoji` key in `NOTIFICATION_PATTERN`. The first emoji is used for part 1, the second for part 2.
+Defaults to `⭐🌟`.
+A string of emojis to use for the `part_emoji` key in `NOTIFICATION_PATTERN`.
+The first emoji is used for part 1, the second for part 2.
+
+A few examples: `🌲🎄`, `🌱🎄`, `🔵🟡`, `🥈🥇`.
 
 #### - `NOTIFICATION_SENDER` (optional)
 
@@ -101,21 +112,31 @@ Sends notification as a message from a bot to given Telegram chats.
 
 Env vars:
 
-- `TELEGRAM_BOT_TOKEN`: (required) Telegram bot token, duh. Ask [@BotFather](https://t.me/botfather) for it.
-- `TELEGRAM_CHAT_IDS`: (required) Comma-separated list of chat IDs to send notifications to. See [Telegram docs](https://core.telegram.org/bots/api#sendmessage) for more info. You can easily get those IDs by writing/forwarding messages to bots like [@JsonDumpBot](https://t.me/JsonDumpBot).
+- `TELEGRAM_BOT_TOKEN`: (required) Telegram bot token.  
+  Ask [@BotFather](https://t.me/botfather) for it.
+- `TELEGRAM_CHAT_IDS`: (required) Comma-separated list of chat IDs to send notifications to.  
+  See [Telegram docs](https://core.telegram.org/bots/api#sendmessage) for more info.  
+  Tip: forward messages to [@JsonDumpBot](https://t.me/JsonDumpBot) and retrieve the chat ids.
 
 #### - `ADVENT_OF_CODE_YEAR` (optional)
 
-Defaults to the current year if already in december, otherwise the previous one.
+Defaults to the latest/current Advent Of Code event.
+(The current year if already in december, otherwise the previous one.)
 
 #### - `CACHE_FILE` (optional)
 
-Defaults to `./cache.json`.
+Defaults to `./cache.json`. Where to store the progress of the leaderboard.
+Without it, the script is useless because it does not remember what it previously sent.
 
 #### - `WEBHOOK_MAX_CONTENT_LENGTH` (optional)
 
 Defaults to `2000`. The maximum number of characters that can be sent.
+Some providers have a character limit restriction.
+When it reaches it, it notifies saying the diff is too large.
 
 ## License
 
 MIT
+
+[GitHub Package registry]: https://github.com/tofran/advent-of-code-leaderboard-notifier/pkgs/container/advent-of-code-leaderboard-notifier
+[Docker Hub]: https://hub.docker.com/r/tofran/advent-of-code-leaderboard-notifier

--- a/README.md
+++ b/README.md
@@ -1,30 +1,36 @@
-# Advent of Code leaderboard notifier (Telegram-enabled fork)
+# Advent of Code leaderboard notifier
 
 Send a webhook or notification when someone from an Advent of Code leaderboard solves a puzzle.
 
-This is a fork of [tofran/advent-of-code-leaderboard-notifier](https://github.com/tofran/advent-of-code-leaderboard-notifier) that:
+We are using this to track the progress of a group of friends on Discord/Telegram.
 
-- enables sending notifications to Telegram (or easily implement another custom webhook sender)
-- adds colored emojis to notifications so they're easier to read at a glance
-- adds event times to notifications (no hours, just ":MM:SS" because timezones, but it's enough for a 15 min interval)
-
-<img src='https://github.com/iburakov/advent-of-code-leaderboard-notifier-telegram/assets/5229130/83e0aad9-1b2f-4453-945c-2ae96b83b091' height='300'>
+<img src='https://github.com/tofran/advent-of-code-leaderboard-notifier/assets/5229130/289bc0e7-5def-4ffa-a21f-53d4eeb8f695' height='200'>
 
 ## Usage
 
 Just run this image whenever you want to check for updates:
 
 ```sh
-# Slack/Discord/custom webhook/etc.
+# Discord/Slack/custom webhook/etc.
 $ docker run \
   -e WEBHOOK_URL="your webhook url" \
   -e ADVENT_OF_CODE_SESSION_ID="your advent of code session id" \
   -e ADVENT_OF_CODE_LEADERBOARD_ID="numeric leaderboard id" \
   -e CACHE_FILE="/cache/cache.json" \
-  # (Optional) -e LOOP_SLEEP_SECONDS="900" \
-  # (Optional, runs it as a background service) --restart=unless-stopped -d \
   -v "$(pwd)/cache/:/cache/" \
-  ghcr.io/iburakov/advent-of-code-leaderboard-notifier-telegram:main
+  # (Optional: run it as a background service)
+  # -e LOOP_SLEEP_SECONDS="900" --restart=unless-stopped -d \
+  # (Optional: customize the emojis in the notification)
+  # -e NOTIFICATION_PATTERN_EMOJIS="⭐🌟"
+  # -e NOTIFICATION_PATTERN_EMOJIS="🌲🎄"
+  # -e NOTIFICATION_PATTERN_EMOJIS="🌱🎄"
+  # -e NOTIFICATION_PATTERN_EMOJIS="🔵🟡"
+  # -e NOTIFICATION_PATTERN_EMOJIS="🥈🥇"
+  # (Optional: customize the notification text, see more keys below)
+  # -e NOTIFICATION_PATTERN="{member} solved {day}.{part} {part_emoji} at {mmss}"
+  # (Optional: customize just the part 2 notification)
+  # -e NOTIFICATION_2_PATTERN="{member} solved the 🎉🍾SECOND 🎄💥 part of day {day}! MORE EMOJIS!!!"
+  ghcr.io/tofran/advent-of-code-leaderboard-notifier
 
 # Telegram
 $ docker run \
@@ -34,10 +40,9 @@ $ docker run \
   -e ADVENT_OF_CODE_SESSION_ID="your advent of code session id" \
   -e ADVENT_OF_CODE_LEADERBOARD_ID="numeric leaderboard id" \
   -e CACHE_FILE="/cache/cache.json" \
-  # (Optional) -e LOOP_SLEEP_SECONDS="900" \
-  # (Optional, runs it as a background service) --restart=unless-stopped -d \
   -v "$(pwd)/cache/:/cache/" \
-  ghcr.io/iburakov/advent-of-code-leaderboard-notifier-telegram:main
+  # (Same optionals, see above)
+  ghcr.io/tofran/advent-of-code-leaderboard-notifier
 
 ```
 
@@ -46,23 +51,70 @@ or pass the `LOOP_SLEEP_SECONDS` env var to make the script loop.
 
 ### Configuration
 
-- `ADVENT_OF_CODE_LEADERBOARD_ID`: The unique ID of the leaderboard. It's an integer you can get from the end of leaderboard url or the prefix of the invite code.
-- `ADVENT_OF_CODE_SESSION_ID`: Your advent of code session id.  
-   To retrieve it, visit adventofcode.com, open developer tools > storage > cookies > copy the value of your `session` cookie.
-- `ADVENT_OF_CODE_YEAR`: Optional, defaults to the current year if already in december, otherwise the previous one.
-- `CACHE_FILE`: Optional, defaults to `./cache.json`
-- `LOOP_SLEEP_SECONDS`: Optional, defaults to `0`, meaning it only runs once and terminates the process. Otherwise set it to how many seconds to sleep between runs. It is recommended a value greater than `900` (15 min).
-- `WEBHOOK_MAX_CONTENT_LENGTH`: Optional, the maximum number of characters that can be sent. Defaults to `2000`.
-- `NOTIFICATION_SENDER`: Optional, allows to select a custom notification sender. Default - `webhook`. Can be set to `telegram` to send notifications to Telegram instead. Each notification sender has its own params. See below and in `notification_senders.py` for more info.
+#### - `ADVENT_OF_CODE_LEADERBOARD_ID`
 
-`webhook` notification sender params:
+The unique ID of the leaderboard. It's an integer you can get from the end of leaderboard url or the prefix of the invite code.
 
-- `WEBHOOK_URL`: Where to send the webhook. For example, a Discord webhook URL.
+#### - `ADVENT_OF_CODE_SESSION_ID`
 
-`telegram` notification sender params:
+Your advent of code session id. To retrieve it, visit adventofcode.com, open developer tools > storage > cookies > copy the value of your `session` cookie.
 
-- `TELEGRAM_BOT_TOKEN`: Your Telegram bot token. Ask [@BotFather](https://t.me/botfather) for it.
-- `TELEGRAM_CHAT_IDS`: Comma-separated list of chat IDs to send notifications to. See [Telegram docs](https://core.telegram.org/bots/api#sendmessage) for more info. You can find them by writing/forwarding messages to bots like [@JsonDumpBot](https://t.me/JsonDumpBot).
+#### - `LOOP_SLEEP_SECONDS` (optional)
+
+Defaults to `0`, meaning it only runs once and terminates the process. Otherwise set it to how many seconds to sleep between runs. It is recommended a value greater than `900` (15 min).
+
+#### - `NOTIFICATION_PATTERN` (optional)
+
+Customizes the notification text. Defaults to `Day {day}: {member} got {part_emoji} after {after}`. Supported keys:
+
+- `member`: the leaderbord member's name
+- `member_id`: the leaderbord member's id
+- `day`: the day number
+- `part`: the part number
+- `part_emoji`: the part emoji (see `NOTIFICATION_PATTERN_EMOJIS`)
+- `mmss`: when the puzzle was solved in `:mm:ss` format (no hours because timezones, still useful given 15 mins check interval)
+- `after`: how much time has passed since puzzle publication when it was solved in `[d] hh:mm:ss` format.
+
+#### - `NOTIFICATION_2_PATTERN` (optional)
+
+Defaults to the current value of `NOTIFICATION_PATTERN`. Customizes just the notification text for part 2 specifically.
+
+#### - `NOTIFICATION_PATTERN_EMOJIS` (optional)
+
+Defaults to `🌱🎄`. A string of emojis to use for the `part_emoji` key in `NOTIFICATION_PATTERN`. The first emoji is used for part 1, the second for part 2.
+
+#### - `NOTIFICATION_SENDER` (optional)
+
+Default - `webhook`. Can be set to `telegram` to send notifications to Telegram instead.
+
+##### `webhook` notification sender
+
+Sends an HTTP POST to the `WEBHOOK_URL` with a JSON body like `{"content": "<notifications>"}`.
+
+Env vars:
+
+- `WEBHOOK_URL`: (required) Where to send the webhook. For example, a Discord webhook URL.
+
+##### `telegram` notification sender
+
+Sends notification as a message from a bot to given Telegram chats.
+
+Env vars:
+
+- `TELEGRAM_BOT_TOKEN`: (required) Telegram bot token, duh. Ask [@BotFather](https://t.me/botfather) for it.
+- `TELEGRAM_CHAT_IDS`: (required) Comma-separated list of chat IDs to send notifications to. See [Telegram docs](https://core.telegram.org/bots/api#sendmessage) for more info. You can easily get those IDs by writing/forwarding messages to bots like [@JsonDumpBot](https://t.me/JsonDumpBot).
+
+#### - `ADVENT_OF_CODE_YEAR` (optional)
+
+Defaults to the current year if already in december, otherwise the previous one.
+
+#### - `CACHE_FILE` (optional)
+
+Defaults to `./cache.json`.
+
+#### - `WEBHOOK_MAX_CONTENT_LENGTH` (optional)
+
+Defaults to `2000`. The maximum number of characters that can be sent.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -22,19 +22,22 @@ $ docker run \
   -e ADVENT_OF_CODE_LEADERBOARD_ID="numeric leaderboard id" \
   -e CACHE_FILE="/cache/cache.json" \
   # (Optional) -e LOOP_SLEEP_SECONDS="900" \
+  # (Optional, runs it as a background service) --restart=unless-stopped -d \
   -v "$(pwd)/cache/:/cache/" \
-  ghcr.io/iburakov/advent-of-code-leaderboard-notifier
+  ghcr.io/iburakov/advent-of-code-leaderboard-notifier-telegram:main
 
 # Telegram
 $ docker run \
+  -e WEBHOOK_SENDER=telegram \
   -e WEBHOOK_TELEGRAM_URL="https://api.telegram.org/bot<token>/sendMessage" \
   -e WEBHOOK_TELEGRAM_CHAT_ID="chat_id_1,chat_id_2" \
   -e ADVENT_OF_CODE_SESSION_ID="your advent of code session id" \
   -e ADVENT_OF_CODE_LEADERBOARD_ID="numeric leaderboard id" \
   -e CACHE_FILE="/cache/cache.json" \
   # (Optional) -e LOOP_SLEEP_SECONDS="900" \
+  # (Optional, runs it as a background service) --restart=unless-stopped -d \
   -v "$(pwd)/cache/:/cache/" \
-  ghcr.io/iburakov/advent-of-code-leaderboard-notifier
+  ghcr.io/iburakov/advent-of-code-leaderboard-notifier-telegram:main
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# Advent of code leaderboard notifier
+# Advent of code leaderboard notifier (Telegram-enabled fork)
+
+This exists thanks to @tofran. The fork just adds the ability to send notifications to Telegram instead of Slack/Discord.
+
+---
+
+## Original README
 
 Send a webhook notification when someone from an Advent Of Code leaderboard solves a puzzle.
 
@@ -26,15 +32,14 @@ or pass the `LOOP_SLEEP_SECONDS` env var to make the script loop.
 
 ### Configuration
 
- - `ADVENT_OF_CODE_LEADERBOARD_ID`: The unique ID of the leaderboard. It's an integer you can get from the end of leaderboard url or the prefix of the invite code.
- - `ADVENT_OF_CODE_SESSION_ID`: Your advent of code session id.  
-    To retrieve it, visit adventofcode.com, open developer tools > storage > cookies > copy the value of your `session` cookie.
- - `WEBHOOK_URL`: Where to send the webhook. For example a Discord webhook URL.
- - `ADVENT_OF_CODE_YEAR`: Optional, defaults to the current year if already in december, otherwise the previous one.
- - `CACHE_FILE`: Optional, defaults to `./cache.json`
- - `LOOP_SLEEP_SECONDS`: Optional, defaults to `0`, meaning it only runs once and terminates the process. Otherwise set it to how many seconds to sleep between runs. It is recommended a value greater than `900` (15 min).
- - `WEBHOOK_MAX_CONTENT_LENGTH`: Optional, the maximum number of characters that can be sent to the webhook. Defaults to `2000`.
-
+- `ADVENT_OF_CODE_LEADERBOARD_ID`: The unique ID of the leaderboard. It's an integer you can get from the end of leaderboard url or the prefix of the invite code.
+- `ADVENT_OF_CODE_SESSION_ID`: Your advent of code session id.  
+   To retrieve it, visit adventofcode.com, open developer tools > storage > cookies > copy the value of your `session` cookie.
+- `WEBHOOK_URL`: Where to send the webhook. For example a Discord webhook URL.
+- `ADVENT_OF_CODE_YEAR`: Optional, defaults to the current year if already in december, otherwise the previous one.
+- `CACHE_FILE`: Optional, defaults to `./cache.json`
+- `LOOP_SLEEP_SECONDS`: Optional, defaults to `0`, meaning it only runs once and terminates the process. Otherwise set it to how many seconds to sleep between runs. It is recommended a value greater than `900` (15 min).
+- `WEBHOOK_MAX_CONTENT_LENGTH`: Optional, the maximum number of characters that can be sent to the webhook. Defaults to `2000`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,21 @@
-# Advent of code leaderboard notifier (Telegram-enabled fork)
-
-This exists thanks to @tofran. The fork just adds the ability to send notifications to Telegram instead of Slack/Discord.
-
----
-
-## Original README
+# Advent of Code leaderboard notifier (Telegram-enabled fork)
 
 Send a webhook notification when someone from an Advent Of Code leaderboard solves a puzzle.
 
-I'm using this to track the progress of a group of friends on Discord.
+This is a fork of [tofran/advent-of-code-leaderboard-notifier](https://github.com/tofran/advent-of-code-leaderboard-notifier) that:
 
-![Example discord notification](https://user-images.githubusercontent.com/5692603/100946056-738cae80-34fa-11eb-833f-645b8ea2e116.png)
+- enables sending notifications to Telegram (or easily implement another custom webhook sender)
+- adds colored emojis to notifications so they're easier to read at a glance
+- adds event times to notifications (no hours, just ":MM:SS" because timezones, but it's enough for a 15 min interval)
+
+<img src='https://github.com/iburakov/advent-of-code-leaderboard-notifier-telegram/assets/5229130/83e0aad9-1b2f-4453-945c-2ae96b83b091' height='300'>
 
 ## Usage
 
 Just run this image whenever you want to check for updates:
 
 ```sh
+# Slack/Discord/custom webhook/etc.
 $ docker run \
   -e WEBHOOK_URL="your webhook url" \
   -e ADVENT_OF_CODE_SESSION_ID="your advent of code session id" \
@@ -24,7 +23,19 @@ $ docker run \
   -e CACHE_FILE="/cache/cache.json" \
   # (Optional) -e LOOP_SLEEP_SECONDS="900" \
   -v "$(pwd)/cache/:/cache/" \
-  ghcr.io/tofran/advent-of-code-leaderboard-notifier
+  ghcr.io/iburakov/advent-of-code-leaderboard-notifier
+
+# Telegram
+$ docker run \
+  -e WEBHOOK_TELEGRAM_URL="https://api.telegram.org/bot<token>/sendMessage" \
+  -e WEBHOOK_TELEGRAM_CHAT_ID="chat_id_1,chat_id_2" \
+  -e ADVENT_OF_CODE_SESSION_ID="your advent of code session id" \
+  -e ADVENT_OF_CODE_LEADERBOARD_ID="numeric leaderboard id" \
+  -e CACHE_FILE="/cache/cache.json" \
+  # (Optional) -e LOOP_SLEEP_SECONDS="900" \
+  -v "$(pwd)/cache/:/cache/" \
+  ghcr.io/iburakov/advent-of-code-leaderboard-notifier
+
 ```
 
 It should exit successfully. Run it periodically (at a minimum interval of 15 min),
@@ -35,11 +46,20 @@ or pass the `LOOP_SLEEP_SECONDS` env var to make the script loop.
 - `ADVENT_OF_CODE_LEADERBOARD_ID`: The unique ID of the leaderboard. It's an integer you can get from the end of leaderboard url or the prefix of the invite code.
 - `ADVENT_OF_CODE_SESSION_ID`: Your advent of code session id.  
    To retrieve it, visit adventofcode.com, open developer tools > storage > cookies > copy the value of your `session` cookie.
-- `WEBHOOK_URL`: Where to send the webhook. For example a Discord webhook URL.
 - `ADVENT_OF_CODE_YEAR`: Optional, defaults to the current year if already in december, otherwise the previous one.
 - `CACHE_FILE`: Optional, defaults to `./cache.json`
 - `LOOP_SLEEP_SECONDS`: Optional, defaults to `0`, meaning it only runs once and terminates the process. Otherwise set it to how many seconds to sleep between runs. It is recommended a value greater than `900` (15 min).
 - `WEBHOOK_MAX_CONTENT_LENGTH`: Optional, the maximum number of characters that can be sent to the webhook. Defaults to `2000`.
+- `WEBHOOK_SENDER`: Optional, allows to select a non-default webhook sender. Can be set to `telegram` to send notifications to Telegram instead. Each webhook sender has its own params. See below and in `webhook_senders.py` for more info.
+
+`default` webhook sender params:
+
+- `WEBHOOK_URL`: Where to send the webhook. For example, a Discord webhook URL.
+
+`telegram` webhook sender params:
+
+- `WEBHOOK_TELEGRAM_URL`: The URL of your Telegram bot's webhook. Usually it's `https://api.telegram.org/bot<token>/sendMessage`. Ask [BotFather](https://t.me/botfather) for a token.
+- `WEBHOOK_TELEGRAM_CHAT_ID`: comma-separated list of chat IDs to send notifications to. See [Telegram docs](https://core.telegram.org/bots/api#sendmessage) for more info. You can find them using bots like [@JsonDumpBot](https://t.me/JsonDumpBot).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Advent of Code leaderboard notifier (Telegram-enabled fork)
 
-Send a webhook notification when someone from an Advent Of Code leaderboard solves a puzzle.
+Send a webhook or notification when someone from an Advent of Code leaderboard solves a puzzle.
 
 This is a fork of [tofran/advent-of-code-leaderboard-notifier](https://github.com/tofran/advent-of-code-leaderboard-notifier) that:
 
@@ -28,9 +28,9 @@ $ docker run \
 
 # Telegram
 $ docker run \
-  -e WEBHOOK_SENDER=telegram \
-  -e WEBHOOK_TELEGRAM_URL="https://api.telegram.org/bot<token>/sendMessage" \
-  -e WEBHOOK_TELEGRAM_CHAT_ID="chat_id_1,chat_id_2" \
+  -e NOTIFICATION_SENDER=telegram \
+  -e TELEGRAM_BOT_TOKEN="bot token" \
+  -e TELEGRAM_CHAT_IDS="chat_id_1,chat_id_2" \
   -e ADVENT_OF_CODE_SESSION_ID="your advent of code session id" \
   -e ADVENT_OF_CODE_LEADERBOARD_ID="numeric leaderboard id" \
   -e CACHE_FILE="/cache/cache.json" \
@@ -52,17 +52,17 @@ or pass the `LOOP_SLEEP_SECONDS` env var to make the script loop.
 - `ADVENT_OF_CODE_YEAR`: Optional, defaults to the current year if already in december, otherwise the previous one.
 - `CACHE_FILE`: Optional, defaults to `./cache.json`
 - `LOOP_SLEEP_SECONDS`: Optional, defaults to `0`, meaning it only runs once and terminates the process. Otherwise set it to how many seconds to sleep between runs. It is recommended a value greater than `900` (15 min).
-- `WEBHOOK_MAX_CONTENT_LENGTH`: Optional, the maximum number of characters that can be sent to the webhook. Defaults to `2000`.
-- `WEBHOOK_SENDER`: Optional, allows to select a non-default webhook sender. Can be set to `telegram` to send notifications to Telegram instead. Each webhook sender has its own params. See below and in `webhook_senders.py` for more info.
+- `WEBHOOK_MAX_CONTENT_LENGTH`: Optional, the maximum number of characters that can be sent. Defaults to `2000`.
+- `NOTIFICATION_SENDER`: Optional, allows to select a custom notification sender. Default - `webhook`. Can be set to `telegram` to send notifications to Telegram instead. Each notification sender has its own params. See below and in `notification_senders.py` for more info.
 
-`default` webhook sender params:
+`webhook` notification sender params:
 
 - `WEBHOOK_URL`: Where to send the webhook. For example, a Discord webhook URL.
 
-`telegram` webhook sender params:
+`telegram` notification sender params:
 
-- `WEBHOOK_TELEGRAM_URL`: The URL of your Telegram bot's webhook. Usually it's `https://api.telegram.org/bot<token>/sendMessage`. Ask [BotFather](https://t.me/botfather) for a token.
-- `WEBHOOK_TELEGRAM_CHAT_ID`: comma-separated list of chat IDs to send notifications to. See [Telegram docs](https://core.telegram.org/bots/api#sendmessage) for more info. You can find them using bots like [@JsonDumpBot](https://t.me/JsonDumpBot).
+- `TELEGRAM_BOT_TOKEN`: Your Telegram bot token. Ask [@BotFather](https://t.me/botfather) for it.
+- `TELEGRAM_CHAT_IDS`: Comma-separated list of chat IDs to send notifications to. See [Telegram docs](https://core.telegram.org/bots/api#sendmessage) for more info. You can find them by writing/forwarding messages to bots like [@JsonDumpBot](https://t.me/JsonDumpBot).
 
 ## License
 

--- a/advent_of_code_notify.py
+++ b/advent_of_code_notify.py
@@ -39,12 +39,11 @@ ADVENT_OF_CODE_SESSION_ID = os.getenv("ADVENT_OF_CODE_SESSION_ID")
 ADVENT_OF_CODE_YEAR = int(os.getenv("ADVENT_OF_CODE_YEAR", get_default_year()))
 LOOP_SLEEP_SECONDS = int(os.getenv("LOOP_SLEEP_SECONDS", "0"))
 WEBHOOK_MAX_CONTENT_LENGTH = int(os.getenv("WEBHOOK_MAX_CONTENT_LENGTH", "2000"))
-# ^ rename to NOTIFICATION_ and break backwards compatibility? worth it?
 NOTIFICATION_SENDER_NAME = os.getenv("NOTIFICATION_SENDER", "webhook")
 
-NOTIFICATION_PATTERN_EMOJIS = os.getenv("NOTIFICATION_PATTERN_EMOJIS", "🌱🎄")
+NOTIFICATION_PATTERN_EMOJIS = os.getenv("NOTIFICATION_PATTERN_EMOJIS", "⭐🌟")
 NOTIFICATION_PATTERN = os.getenv(
-    "NOTIFICATION_PATTERN", "Day {day}: {member} got {part_emoji} after {after}"
+    "NOTIFICATION_PATTERN", "Day {day}: {member} solved {part_emoji} after {after}"
 )
 NOTIFICATION_2_PATTERN = os.getenv("NOTIFICATION_2_PATTERN", NOTIFICATION_PATTERN)
 
@@ -130,7 +129,7 @@ def format_unix_timedelta(td: int) -> str:
     if td < 0:
         return "-" + format_unix_timedelta(-td)
 
-    d, mod = divmod(td, 86400)
+    d, mod = divmod(td, 3600 * 24)
     h, mod = divmod(mod, 3600)
     m, s = divmod(mod, 60)
     hms = f"{h:02}:{m:02}:{s:02}"

--- a/advent_of_code_notify.py
+++ b/advent_of_code_notify.py
@@ -195,7 +195,7 @@ def main():
         try:
             run()
         except Exception:
-            logging.exception("error while running run()")
+            logging.exception("error while doing run()")
 
         logging.info(f"Sleeping {LOOP_SLEEP_SECONDS}s")
         sleep(LOOP_SLEEP_SECONDS)

--- a/advent_of_code_notify.py
+++ b/advent_of_code_notify.py
@@ -38,9 +38,15 @@ ADVENT_OF_CODE_LEADERBOARD_ID = os.getenv("ADVENT_OF_CODE_LEADERBOARD_ID")
 ADVENT_OF_CODE_SESSION_ID = os.getenv("ADVENT_OF_CODE_SESSION_ID")
 ADVENT_OF_CODE_YEAR = int(os.getenv("ADVENT_OF_CODE_YEAR", get_default_year()))
 LOOP_SLEEP_SECONDS = int(os.getenv("LOOP_SLEEP_SECONDS", "0"))
-NOTIFICATION_SENDER_NAME = os.getenv("NOTIFICATION_SENDER", "webhook")
 WEBHOOK_MAX_CONTENT_LENGTH = int(os.getenv("WEBHOOK_MAX_CONTENT_LENGTH", "2000"))
 # ^ rename to NOTIFICATION_ and break backwards compatibility? worth it?
+NOTIFICATION_SENDER_NAME = os.getenv("NOTIFICATION_SENDER", "webhook")
+
+NOTIFICATION_PATTERN_EMOJIS = os.getenv("NOTIFICATION_PATTERN_EMOJIS", "🌱🎄")
+NOTIFICATION_PATTERN = os.getenv(
+    "NOTIFICATION_PATTERN", "Day {day}: {member} got {part_emoji} at {when}"
+)
+NOTIFICATION_2_PATTERN = os.getenv("NOTIFICATION_2_PATTERN", NOTIFICATION_PATTERN)
 
 assert ADVENT_OF_CODE_LEADERBOARD_ID, "ADVENT_OF_CODE_LEADERBOARD_ID missing"
 assert ADVENT_OF_CODE_SESSION_ID, "ADVENT_OF_CODE_SESSION_ID missing"
@@ -135,14 +141,22 @@ def run():
 
     messages = []
     for member_id, day, part, when_ts in diff:
-        part_emoji = {
-            "1": "🔵",
-            "2": "🟡",
-        }.get(part, f"star {part}")
-        when = format_ts(when_ts)
-        member = get_name(new_leaderboard, member_id)
+        emojis = NOTIFICATION_PATTERN_EMOJIS
+        part_index = int(part) - 1
 
-        messages.append(f"Day {day}: {member} got {part_emoji} at {when}")
+        pattern = NOTIFICATION_PATTERN if part == "1" else NOTIFICATION_2_PATTERN
+        messages.append(
+            pattern.format(
+                member_id=member_id,
+                member=get_name(new_leaderboard, member_id),
+                day=day,
+                when=format_ts(when_ts),
+                part=part,
+                part_emoji=(
+                    emojis[part_index] if 0 <= part_index <= len(emojis) else part
+                ),
+            )
+        )
 
     logging.info(f"Leaderboard changed: {messages}")
 

--- a/advent_of_code_notify.py
+++ b/advent_of_code_notify.py
@@ -145,7 +145,11 @@ def main():
         return
 
     while True:
-        run()
+        try:
+            run()
+        except Exception:
+            logging.exception("error while running run()")
+
         logging.info(f"Sleeping {LOOP_SLEEP_SECONDS}s")
         sleep(LOOP_SLEEP_SECONDS)
 

--- a/advent_of_code_notify.py
+++ b/advent_of_code_notify.py
@@ -4,11 +4,8 @@
 # Send a webhook notification when someone from an Advent Of Code
 # leaderboard solves a puzzle
 #
-# tofran, dec 2020
+# tofran and contributors, dec 2020
 # https://github.com/tofran/advent-of-code-leaderboard-notifier
-#
-# iburakov, dec 2023
-# - Telegram notifications
 
 import json
 import logging

--- a/notification_senders.py
+++ b/notification_senders.py
@@ -52,14 +52,14 @@ class TelegramSender(BaseNotificationSender):
         )
 
     def send(self, content):
-        for chat_id in self.chat_ids.split(","):
+        for chat_id in self.chat_ids:
             try:
                 requests.post(
                     f"https://api.telegram.org/bot{self.bot_token}/sendMessage",
-                    json={
-                        "chat_id": self.chat_ids.strip(),
-                        "text": content,
-                    },
+                    json=dict(
+                        chat_id=chat_id,
+                        text=content,
+                    ),
                     headers={"Content-Type": "application/json"},
                 ).raise_for_status()
             except Exception:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@
 flake8==6.1.0
 isort==5.12.0
 pycodestyle==2.11.1
+autopep8==2.0.4

--- a/webhook_senders.py
+++ b/webhook_senders.py
@@ -61,7 +61,7 @@ class TelegramSender(WebhookSender):
                 requests.post(
                     self.webhook_url,
                     json={
-                        "chat_id": self.chat_id,
+                        "chat_id": self.chat_id.strip(),
                         "text": content,
                     },
                     headers={"Content-Type": "application/json"},

--- a/webhook_senders.py
+++ b/webhook_senders.py
@@ -1,0 +1,70 @@
+import os
+from abc import ABC, abstractmethod
+from venv import logger
+
+import requests
+
+
+class WebhookSender(ABC):
+    # __init__() should load required parameters from env vars
+
+    @abstractmethod
+    def send(self, content):
+        ...
+
+
+class DefaultSender(WebhookSender):
+    """
+    Sends a notification to Slack/Discord/etc.
+
+    Body is a JSON object with a "content" key.
+    """
+
+    def __init__(self):
+        self.webhook_url = os.getenv("WEBHOOK_URL")
+        assert self.webhook_url, "WEBHOOK_URL is missing"
+
+    def send(self, content):
+        requests.post(
+            self.webhook_url,
+            json={
+                "content": content,
+            },
+            headers={"Content-Type": "application/json"},
+        ).raise_for_status()
+
+
+class TelegramSender(WebhookSender):
+    """
+    Sends a notification to Telegram chats.
+
+    Body is a JSON object with "chat_id" and "text" keys.
+    """
+
+    def __init__(self):
+        self.webhook_url = os.getenv("WEBHOOK_TELEGRAM_URL")
+        assert self.webhook_url, (
+            "WEBHOOK_TELEGRAM_URL is missing, "
+            "https://api.telegram.org/bot<token>/sendMessage is expected."
+        )
+
+        self.chat_id = os.getenv("WEBHOOK_TELEGRAM_CHAT_ID")
+        assert self.chat_id, (
+            "WEBHOOK_TELEGRAM_CHAT_ID is missing, "
+            "a comma-separated list of chat IDs to send notification to is expected "
+            "(see https://core.telegram.org/bots/api#sendmessage)."
+        )
+
+    def send(self, content):
+        for chat_id in self.chat_id.split(","):
+            try:
+                requests.post(
+                    self.webhook_url,
+                    json={
+                        "chat_id": self.chat_id,
+                        "text": content,
+                    },
+                    headers={"Content-Type": "application/json"},
+                ).raise_for_status()
+            except Exception:
+                logger.exception(f"failed to send notification to chat {chat_id}")


### PR DESCRIPTION
Hi there! Thanks for sharing this code, it was very helpful. 

I've done some further work on it for my own requirements and created a [fork](https://github.com/iburakov/advent-of-code-leaderboard-notifier-telegram) as a separate repo with its own builds for the time being. 

Just suggesting you to take a look, because I have nothing against merging this work back to yours (if you consider it reasonable, of course).

I've simplified writing custom webhook senders and implemented one for Telegram. I've also added colors and event times to notifications, so now they look like this:

<img src='https://github.com/iburakov/advent-of-code-leaderboard-notifier-telegram/assets/5229130/83e0aad9-1b2f-4453-945c-2ae96b83b091' height='300'>

The formatting part is pretty opinionated, yeah. If you don't like it, a way to please everyone would be to accept pattern str in another env var and do a `.format(day=..., part=..., part_emoji=...)`. So, your format becomes `NOTIFICATION_PATTERN="{member} solved day {day} part {part}"`, mine becomes `NOTIFICATION_PATTERN="Day {day}: {member} got {part_emoji} at {when}"`, users can come up with every other thing they like, etc.

So, if you're open to merging it, let me know, because (at least) a README needs some changes for it to be mergeable :) Otherwise feel free to close this PR.